### PR TITLE
[Fix] Fix CI

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -28,6 +28,7 @@ jobs:
         run: dbt --version
 
       - name: Install dbt deps
+        working-directory: ./transform/nba_dwh
         run: dbt deps
 
       - name: Run dbt


### PR DESCRIPTION
Docs generation stopped working due to configuration not found when installing dbt package. It can be fixed by setting the correct working directory